### PR TITLE
FIX: script does not run

### DIFF
--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -250,7 +250,7 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
     args = parse_args()
     try:
-        main(args)
+        _main(args)
     finally:
         if not args.dry_run:
             logging.info('Cleaning up')


### PR DESCRIPTION
`main()` calls `main(args)` instead of `_main(args)`