### PR TITLE
MNT: skip pre-commit hooks

### DIFF
--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -232,7 +232,7 @@ def _main(args=None):
 
     logging.info('Committing changes')
     commit_message = "Tagging version {version}".format(version=args.version_string)
-    newCommit = repoIndex.commit(commit_message)
+    newCommit = repoIndex.commit(commit_message, skip_hooks=True)
 
     #Tag this commit
     repo.create_tag(args.version_string, ref='HEAD', message=commit_message)


### PR DESCRIPTION
closes #11 

Thankfully this was just a kwarg option and nothing roundabout needed to be done