### PR TITLE
FIX: replace dash with underscore in title

### DIFF
--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -186,7 +186,7 @@ def _main(args=None):
         iBuild = build,
         iRevision = revision,
         sVersion = version_string,
-        title = str(title_tag.text).replace(' ', '_')
+        title = str(title_tag.text).replace(' ', '_').replace('-', '_')
     )
 
     declaration.text = etree.CDATA( pattern.sub(replacement_string, declaration_text) )#Note, using the declaration.text not _ to write it back


### PR DESCRIPTION
Dash is a common package name character, but it is invalid in TwinCAT identifiers
closes #14 