### PR TITLE
ENH: --deploy arg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.5.2
+    hooks:
+    -   id: isort

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include versioneer.py
 include requirements.txt
 include README.md
 include tc_release/_version.py
+include tc_release/tcgvl.txt

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,21 @@
-from setuptools import setup, find_packages
-import versioneer
+from setuptools import find_packages, setup
 
+import versioneer
 
 with open('requirements.txt', 'rt') as f:
     requirements = f.read().splitlines()
 
 requirements = [r for r in requirements if not r.startswith('git+')]
+
+# package_data is required for source distributions
+with open('MANIFEST.in', 'rt') as f:
+    manifest = f.read().splitlines()
+
+# Remove the "include" from the manifest to get filenames
+files = [m.split(' ')[1] for m in manifest]
+# Only include contents of tc_release folder
+files = [f.split('/')[1] for f in files if 'tc_release' in f]
+package_data = {'tc_release': files}
 
 setup(
     name='tc_release',
@@ -14,9 +24,10 @@ setup(
     license='BSD',
     author='SLAC National Accelerator Laboratory',
     install_requires=requirements,
-    packages= find_packages(),
+    packages=find_packages(),
     description='A TwinCAT project release tool',
     include_package_data=True,
+    package_data=package_data,
     entry_points={
         'console_scripts': [
             'tc-release = tc_release.tc_release:main'

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -181,7 +181,7 @@ def make_deploy(args):
     epics_site_top = os.environ.get('EPICS_SITE_TOP', '/cds/group/pcds/epics')
     ioc_dir = os.path.join(epics_site_top, 'ioc')
     categories = next(os.walk(ioc_dir))[1]
-    repo_name = os.path.split(repo_url).replace('.git', '')
+    repo_name = os.path.split(repo_url)[-1].replace('.git', '')
     repo_parts = repo_name.split('-')
 
     correct_category = None
@@ -229,7 +229,7 @@ def make_release(args):
 
     repo.heads.master.set_tracking_branch(origin.refs.master)
 
-    if args.version_string in (tag.tag.tag for tag in repo.tags):
+    if args.version_string in (tag.tag for tag in repo.tags):
         print(f'Tag {args.version} already exists, skipping')
         return
 

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -252,6 +252,7 @@ def make_release(args):
 
     if args.version_string in (tag.name for tag in repo.tags):
         print(f'Tag {args.version_string} already exists, skipping')
+        repo.close()
         return
 
     # Check format of version_number
@@ -430,11 +431,14 @@ def make_release(args):
     # Push commit
     # --tags is not ideal, but since this is the only tag we're creating
     # in this temp area, it should be safe
-    if not args.dry_run:
+    if args.dry_run:
+        pushStatus = None
+    else:
         pushStatus = origin.push(tags=True)
         logging.info('Push complete')
-        repo.close()
-        return pushStatus
+
+    repo.close()
+    return pushStatus
 
 
 def _main(args):

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -476,7 +476,7 @@ def configure_logging(args):
             level = logging.INFO
             valid_config = False
 
-    logging.basicConfig(level=level)
+    logging.basicConfig(level=level, format='%(levelname)-8s %(message)s')
 
     if not valid_config:
         logger.warning(f'Invalid logging specification {args.log_level}! '

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -175,7 +175,8 @@ def _main(args=None):
                   working_dir, args.repo_url)
     origin = repo.create_remote('origin', str(args.repo_url))
 
-    assert origin.exists()
+    if not origin.exists():
+        raise RuntimeError('Repo URL does not exist!')
 
     origin.fetch()
 

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -37,20 +37,9 @@ from git import Repo  # isort:skip
 
 working_dir = os.path.join(os.getcwd(), dirname)
 
-GlobalVersion_TcGVL = '''
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.10">
-  <GVL Name="Global_Version" Id="{c1e6c8db-11ef-4bd5-8510-07e605ee5d06}">
-    <Declaration><![CDATA[{attribute 'TcGenerated'}
-// This function has been automatically generated from the project information.
-VAR_GLOBAL CONSTANT
-    {attribute 'const_non_replaced'}
-    {attribute 'linkalways'}
-    stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 0, iMinor := 1, iBuild := 4, iRevision := 0, sVersion := '0.1.4');
-END_VAR
-]]></Declaration>
-  </GVL>
-</TcPlcObject>
-'''
+template_file = os.path.join(os.dirname(__file__), 'tcgvl.txt')
+with open(template_file, 'r') as fd:
+    GlobalVersion_TcGVL = fd.read()
 
 
 def parse_args():

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -163,7 +163,7 @@ def deploy(repo_url, tag, directory):
             subprocess.run('make')
 
 
-def _main(args=None):
+def make_release(args):
     # Create a temp directory, and clone the repo, and check out master
 
     logging.info('Creating working directory: %s', working_dir)
@@ -367,6 +367,10 @@ def _main(args=None):
         logging.info('Push complete')
         repo.close()
         return pushStatus
+
+
+def _main(args):
+    return make_release(args)
 
 
 def main():

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -3,6 +3,7 @@ import contextlib
 import shutil
 import subprocess
 import os, re, fnmatch, getpass, stat, os.path
+import sys
 import logging
 import uuid
 from lxml import etree
@@ -17,10 +18,15 @@ if os.path.exists(local_git_install):
     os.environ['GIT_SSH'] = local_git_install+'usr\\bin\\ssh.exe'
 from git import Repo
 
+# Working directory
+if 'win' in sys.platform:
+    # Follow windows standard for working directory
+    dirname = '~tc-release-tmp'
+else:
+    # Follow linux standard for working directory
+    dirname = '.tc-release-tmp'
 
-#Working directory
-dirname = '~tc-release-tmp'
-working_dir =os.path.join(os.getcwd(), dirname)
+working_dir = os.path.join(os.getcwd(), dirname)
 
 GlobalVersion_TcGVL = '''\
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.10">

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -71,12 +71,11 @@ def parse_args():
     parser.add_argument('--dry-run', action='store_true',
                         help=('Run without pushing back to the repo and '
                               'without cleaning up the checkout directory.'))
-    parser.add_argument('--log-level', type=str, default='info',
-                        help=('Python logging level, either a string '
-                              'matching the standard log level names '
-                              '(debug, info, warning, error, critical) '
-                              'or an integer. All log messages at the input '
-                              'level or higher will be shown.'))
+    parser.add_argument('--verbose', '-v', action='count', default=0,
+                        help=('Increase the number of messages shown '
+                              'to terminal. This decreases '
+                              'the log level by 10 for each count of v, '
+                              'defaulting to info level.'))
     return parser.parse_args()
 
 
@@ -464,23 +463,8 @@ def _main(args):
 
 
 def configure_logging(args):
-    valid_config = True
-    level = args.log_level
-
-    try:
-        level = getattr(logging, level.upper())
-    except Exception:
-        try:
-            level = int(level)
-        except Exception:
-            level = logging.INFO
-            valid_config = False
-
+    level = logging.INFO - args.verbose * 10
     logging.basicConfig(level=level, format='%(levelname)-8s %(message)s')
-
-    if not valid_config:
-        logger.warning(f'Invalid logging specification {args.log_level}! '
-                       'Falling back to info level.')
 
 
 def main():

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -297,15 +297,17 @@ def make_release(args):
 
     # Getting the ProjectVersion, Company, Author and Title tags
     projectVersion_tag = plcproj_root.find('.//ProjectVersion', nsmap)
-    if projectVersion_tag is None:
-        err = ('Did not find a plc project version tag! Did you forgot to '
-               'set the plc project version to 0.0.0 in TwinCAT?')
-        repo.close()
-        raise RuntimeError(err)
     # company_tag and author_tag are currently unused
     # company_tag = plcproj_root.find('.//Company', nsmap)
     # author_tag = plcproj_root.find('.//Author', nsmap)
     title_tag = plcproj_root.find('.//Title', nsmap)
+
+    if None in (projectVersion_tag, title_tag):
+        err = ('Did not find a plc project version tag or a title tag! '
+               'Did you forgot to set the plc project version to 0.0.0 '
+               'or select an appropriate project title in TwinCAT?')
+        repo.close()
+        raise RuntimeError(err)
 
     logging.info('Updating plcproj with version number: %s', version_string)
     # Adding version string to plcproj

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -480,9 +480,11 @@ def main():
         logger.debug(error_msg, exc_info=True)
         logger.error(error_msg)
     finally:
-        if not args.dry_run:
+        repo.close()
+        if args.dry_run:
+            logger.info(f'Skipping cleanup for dry-run: see {working_dir}.')
+        else:
             logger.info('Cleaning up')
-            repo.close()
             shutil.rmtree(working_dir, onerror=remove_readonly)
 
 

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -298,10 +298,10 @@ def make_release(args):
     # Getting the ProjectVersion, Company, Author and Title tags
     projectVersion_tag = plcproj_root.find('.//ProjectVersion', nsmap)
     if projectVersion_tag is None:
-        print('Did not find a plc project version tag! Did you forgot to '
-              'set the plc project version to v0.0.0?')
+        err = ('Did not find a plc project version tag! Did you forgot to '
+               'set the plc project version to 0.0.0 in TwinCAT?')
         repo.close()
-        raise RuntimeError('Missing ProjectVersion tag')
+        raise RuntimeError(err)
     # company_tag and author_tag are currently unused
     # company_tag = plcproj_root.find('.//Company', nsmap)
     # author_tag = plcproj_root.find('.//Author', nsmap)

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -229,8 +229,8 @@ def make_release(args):
 
     repo.heads.master.set_tracking_branch(origin.refs.master)
 
-    if args.version_string in (tag.tag for tag in repo.tags):
-        print(f'Tag {args.version} already exists, skipping')
+    if args.version_string in (tag.name for tag in repo.tags):
+        print(f'Tag {args.version_string} already exists, skipping')
         return
 
     # Check format of version_number

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -71,6 +71,12 @@ def parse_args():
     parser.add_argument('--dry-run', action='store_true',
                         help=('Run without pushing back to the repo and '
                               'without cleaning up the checkout directory.'))
+    parser.add_argument('--log-level', type=str, default='info',
+                        help=('Python logging level, either a string '
+                              'matching the standard log level names '
+                              '(debug, info, warning, error, critical) '
+                              'or an integer. All log messages at the input '
+                              'level or higher will be shown.'))
     return parser.parse_args()
 
 
@@ -457,9 +463,29 @@ def _main(args):
     make_deploy(args)
 
 
+def configure_logging(args):
+    valid_config = True
+    level = args.log_level
+
+    try:
+        level = getattr(logging, level.upper())
+    except Exception:
+        try:
+            level = int(level)
+        except Exception:
+            level = logging.INFO
+            valid_config = False
+
+    logging.basicConfig(level=level)
+
+    if not valid_config:
+        logger.warning(f'Invalid logging specification {args.log_level}! '
+                       'Falling back to info level.')
+
+
 def main():
-    logging.basicConfig(level=logging.DEBUG)
     args = parse_args()
+    configure_logging(args)
     try:
         _main(args)
     finally:

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -37,7 +37,7 @@ from git import Repo  # isort:skip
 
 working_dir = os.path.join(os.getcwd(), dirname)
 
-template_file = os.path.join(os.dirname(__file__), 'tcgvl.txt')
+template_file = os.path.join(os.path.dirname(__file__), 'tcgvl.txt')
 with open(template_file, 'r') as fd:
     GlobalVersion_TcGVL = fd.read()
 

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -297,6 +297,11 @@ def make_release(args):
 
     # Getting the ProjectVersion, Company, Author and Title tags
     projectVersion_tag = plcproj_root.find('.//ProjectVersion', nsmap)
+    if projectVersion_tag is None:
+        print('Did not find a plc project version tag! Did you forgot to '
+              'set the plc project version to v0.0.0?')
+        repo.close()
+        raise RuntimeError('Missing ProjectVersion tag')
     # company_tag and author_tag are currently unused
     # company_tag = plcproj_root.find('.//Company', nsmap)
     # author_tag = plcproj_root.find('.//Author', nsmap)
@@ -304,6 +309,7 @@ def make_release(args):
 
     logging.info('Updating plcproj with version number: %s', version_string)
     # Adding version string to plcproj
+
     projectVersion_tag.text = version_string
 
     # To make this verson number available in the PLC runtime,

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -104,7 +104,7 @@ def deploy(repo_url, tag, directory):
     """
     # Clone the repo
     deploy_dir = os.path.join(directory, tag)
-    clone_from(repo_url, deploy_dir, depth=1, branch=tag)
+    Repo.clone_from(repo_url, deploy_dir, depth=1, branch=tag)
 
     walker = os.walk(deploy_dir)
     make_dirs = []

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -170,7 +170,7 @@ def deploy(repo_url, tag, directory, dry_run):
     """
     # Clone the repo
     deploy_dir = os.path.join(directory, tag)
-    print(f'Deploying to {deploy_dir}')
+    logger.info(f'Deploying to {deploy_dir}')
     if not dry_run:
         Repo.clone_from(repo_url, deploy_dir, depth=1, branch=tag)
 
@@ -214,8 +214,9 @@ def make_deploy(args):
         deploy_path = os.path.join(ioc_dir, correct_category)
 
     if not os.path.isdir(deploy_path):
-        print(f'{deploy_path} does not exist! '
-              'Verify you used a valid path!')
+        logger.error(f'{deploy_path} does not exist! '
+                     'Verify you used a valid path!')
+        return
 
     repo_deploy_path = os.path.join(deploy_path, repo_name)
 
@@ -225,7 +226,7 @@ def make_deploy(args):
         except FileExistsError:
             pass
 
-    print(f'Deploying {repo_name} to {repo_deploy_path} at {tag}')
+    logger.info(f'Deploying {repo_name} to {repo_deploy_path} at {tag}')
     deploy(repo_url, tag, repo_deploy_path, dry_run)
 
 
@@ -253,7 +254,7 @@ def make_release(args):
     repo.heads.master.set_tracking_branch(origin.refs.master)
 
     if args.version_string in (tag.name for tag in repo.tags):
-        print(f'Tag {args.version_string} already exists, skipping')
+        logger.warning(f'Tag {args.version_string} already exists, skipping')
         repo.close()
         return
 
@@ -262,7 +263,7 @@ def make_release(args):
     version_string = re.search(projectVersion_pattern,
                                args.version_string).group(1)
     if not version_string:
-        print('Error, version string does not match format "vX.X.X"')
+        logger.error('Error, version string does not match format "vX.X.X"')
         exit(1)
 
     # Inject version_number into .tcproj
@@ -272,7 +273,7 @@ def make_release(args):
     plcproj_path = find('*.plcproj', working_dir)
 
     if not len(plcproj_path):
-        print('Error, did not find .plcproj file.')
+        logger.error('Error, did not find .plcproj file.')
         exit(1)
     elif args.plcproj:
         for i, proj in enumerate(plcproj_path):
@@ -280,11 +281,11 @@ def make_release(args):
                 plcproj_file = plcproj_path[i]
                 break
         else:
-            print(('Error, did not find specified file '
-                   '{}.plcproj'.format(args.plcproj)))
+            logger.error(('Error, did not find specified file '
+                          '{}.plcproj'.format(args.plcproj)))
             exit(1)
     elif len(plcproj_path) > 1:
-        print('Error, found multiple .plcproj files.')
+        logger.error('Error, found multiple .plcproj files.')
         exit(1)
     else:
         plcproj_file = plcproj_path[0]
@@ -348,7 +349,7 @@ def make_release(args):
     try:
         gvl_attrib['Id'] = str(uuid.uuid4())
     except KeyError:
-        print('Error, could not find Id attribute in GVL tag...')
+        logger.error('Error, could not find Id attribute in GVL tag...')
         exit(1)
 
     # Now we modify the title and version numbers

--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -413,13 +413,14 @@ def make_release(args, repo):
     logger.info('Linking Global_Version.TcGVL into plcproj')
 
     # Check if Version folder is already linked, if not add it
-    if not plcproj_root.find(".//ItemGroup/Folder[@Include='Version']", nsmap):
+    ver_find = ".//ItemGroup/Folder[@Include='Version']"
+    if not len(plcproj_root.find(ver_find, nsmap)):
         folder = plcproj_root.find('.//ItemGroup/Folder', nsmap)
         folder.addnext(etree.XML('<Folder Include="Version" />'))
 
     # Check if Compile Include if not add it (it better already be there)
-    ver_comp = r'.//ItemGroup/Compile[@Include="Version\Global_Version.TcGVL"]'
-    if not plcproj_root.find(ver_comp, nsmap):
+    comp_find = r'.//ItemGroup/Compile[@Include="Version\Global_Version.TcGVL"]'
+    if not len(plcproj_root.find(comp_find, nsmap)):
         compile_include = plcproj_root.find('.//ItemGroup/Compile', nsmap)
         compile_include.addnext(etree.XML(r'''
         <Compile Include="Version\Global_Version.TcGVL">

--- a/tc_release/tcgvl.txt
+++ b/tc_release/tcgvl.txt
@@ -1,0 +1,12 @@
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.10">
+  <GVL Name="Global_Version" Id="{c1e6c8db-11ef-4bd5-8510-07e605ee5d06}">
+    <Declaration><![CDATA[{attribute 'TcGenerated'}
+// This function has been automatically generated from the project information.
+VAR_GLOBAL CONSTANT
+    {attribute 'const_non_replaced'}
+    {attribute 'linkalways'}
+    stLibVersion_LCLS_General : ST_LibVersion := (iMajor := 0, iMinor := 1, iBuild := 4, iRevision := 0, sVersion := '0.1.4');
+END_VAR
+]]></Declaration>
+  </GVL>
+</TcPlcObject>


### PR DESCRIPTION
Changes:
- Add a `--deploy` arg that clones a tag to the production directory and makes the IOC
- Add a `--deploy-path` arg that overrides the default install directory
- Use `flake8` and `isort` to standardize the style to match the other pcdshub packages
- Add standard pre commit checks that I found helpful while writing this
- Miscellaneous error handling that I noticed while trying to deploy `lcls-plc-kfe-motion`
- Add `--verbose`/`-v` argument
- Make script more consistent about using logging vs printing (always log to module logger)
- Make error checking and cleanup more consistent
- Handle `FutureWarning` from xml library

Questions:
- This adds an implied `pytmc` dependency, should it be explicit in the recipe?
- Did I pick the correct folder to deploy in? `/cds/group/epics/ioc/<hutch>/<repo>/<version>`

closes #18

Recent IOC deploys for LFE and KFE motion:
```
$ tc-release --deploy v1.2.1 git@github.com:pcdshub/lcls-plc-lfe-motion.git
INFO:root:Creating working directory: /cds/home/z/zlentz/temp/.tc-release-tmp
INFO:root:Initializing bare git repo, establishing remote, and checking out master
DEBUG:git.cmd:Popen(['git', 'init'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
INFO:root:Adding remote
DEBUG:root:Working directory: /cds/home/z/zlentz/temp/.tc-release-tmp, Repo: git@github.com:pcdshub/lcls-plc-lfe-motion.git
DEBUG:git.cmd:Popen(['git', 'remote', 'add', 'origin', 'git@github.com:pcdshub/lcls-plc-lfe-motion.git'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'fetch', '-v', 'origin'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=True, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'cat-file', '--batch-check'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=<valid stream>)
DEBUG:git.cmd:Popen(['git', 'checkout', 'master'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
Tag v1.2.1 already exists, skipping
Deploying lcls-plc-lfe-motion to /cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion at v1.2.1
Deploying to /cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1
DEBUG:git.cmd:Popen(['git', 'clone', '--branch=v1.2.1', '--depth=1', '-v', 'git@github.com:pcdshub/lcls-plc-lfe-motion.git', '/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1'], cwd=/cds/home/z/zlentz/temp, universal_newlines=True, shell=None, istream=None)
DEBUG:git.repo.base:Cmd(['git', 'clone', '--branch=v1.2.1', '--depth=1', '-v', 'git@github.com:pcdshub/lcls-plc-lfe-motion.git', '/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1'])'s unused stdout:
-----------------------------------------------------------
Build path: /cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/.pytmc_build
PLC: lfe_motion
IOC name: ioc-lfe-motion
PYTMC_OPTS:
PROJECT_PATH: ../../plc-lfe-motion/plc-lfe-motion.tsproj
Absolute project path:  /cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/plc-lfe-motion/plc-lfe-motion.tsproj
-----------------------------------------------------------


mkdir -p "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/.pytmc_build"
make[1]: Entering directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'
* Found pytmc v 2.8.0
Executing pytmc stcmd: creating st.cmd...
cd "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/.pytmc_build" && \
        pytmc stcmd \
        --name "ioc-lfe-motion" \
        --plc "lfe_motion" \
        --template-path "/reg/g/pcds/epics/ioc/common/ads-ioc/R0.3.1/iocBoot/templates" \
        --template "st.cmd.template" \
        --hashbang "/reg/g/pcds/epics/ioc/common/ads-ioc/R0.3.1/bin/rhel7-x86_64/adsIoc" \
        --only-motor \
        -p "PLC:LFE:MOTION" \
         \
        "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/plc-lfe-motion/plc-lfe-motion.tsproj" > st.cmd
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'
make[1]: Entering directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'
* Found pytmc v 2.8.0
Executing pytmc db: creating lfe_motion.db and lfe_motion.archive...
cd "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/.pytmc_build" && \
        pytmc db \
        --plc "lfe_motion" \
        "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/plc-lfe-motion/plc-lfe-motion.tsproj" \
        "lfe_motion.db"
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'
make[1]: Entering directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'
* Copying envPaths and fixing IOC_TOP...
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'
make[1]: Entering directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'

* Copying st.cmd and databases...
* Changing permissions on the old st.cmd...
* Found database files to install; creating load_plc_databases.cmd...
* Installing: lfe_motion.db
* Installing: st.cmd
install -p -m 0555 "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/.pytmc_build/st.cmd" "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion";
* Installing: load_plc_databases.cmd
install -p -m 0444 "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/.pytmc_build/load_plc_databases.cmd" "/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion";
* Installing archive file: lfe_motion.db.archive
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion'

Build complete.
Creating IOC data directory
install --mode 0775 --group ps-ioc --directory /reg/d/iocData/ioc-lfe-motion/{iocInfo,archive,logs,autosave}
Creating autosave files directory
install --mode 0775 --group ps-ioc --directory /cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/autosave

* Cleaning...
Done
INFO:root:Cleaning up

$ ls /cds/group/pcds/epics/ioc/lfe/lcls-plc-lfe-motion/v1.2.1/iocBoot/ioc-lfe-motion/
autosave  envPaths  lfe_motion.db  lfe_motion.db.archive  load_plc_databases.cmd  Makefile  st.cmd
```
```
$ tc-release --deploy v1.3.2 git@github.com:pcdshub/lcls-plc-kfe-motion.git
INFO:root:Creating working directory: /cds/home/z/zlentz/temp/.tc-release-tmp
INFO:root:Initializing bare git repo, establishing remote, and checking out master
DEBUG:git.cmd:Popen(['git', 'init'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
INFO:root:Adding remote
DEBUG:root:Working directory: /cds/home/z/zlentz/temp/.tc-release-tmp, Repo: git@github.com:pcdshub/lcls-plc-kfe-motion.git
DEBUG:git.cmd:Popen(['git', 'remote', 'add', 'origin', 'git@github.com:pcdshub/lcls-plc-kfe-motion.git'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'fetch', '-v', 'origin'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=True, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'cat-file', '--batch-check'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=<valid stream>)
DEBUG:git.cmd:Popen(['git', 'checkout', 'master'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
INFO:root:Looking for .plcproj
INFO:root:Parsing plcproj
INFO:root:Cleaning up
Traceback (most recent call last):
  File "/reg/neh/home/zlentz/miniconda3/envs/dev/bin/tc-release", line 33, in <module>
    sys.exit(load_entry_point('tc-release==0.1.4', 'console_scripts', 'tc-release')())
  File "/cds/home/z/zlentz/github/tc_release/tc_release/tc_release.py", line 461, in main
    _main(args)
  File "/cds/home/z/zlentz/github/tc_release/tc_release/tc_release.py", line 453, in _main
    make_release(args)
  File "/cds/home/z/zlentz/github/tc_release/tc_release/tc_release.py", line 310, in make_release
    raise RuntimeError(err)
RuntimeError: Did not find a plc project version tag or a title tag! Did you forgot to set the plc project version to 0.0.0 or select an appropriate project title in TwinCAT?
zlentz@psbuild-rhel7-01$ tc-release --deploy v1.3.2 git@github.com:pcdshub/lcls-plc-kfe-motion.git
INFO:root:Creating working directory: /cds/home/z/zlentz/temp/.tc-release-tmp
INFO:root:Initializing bare git repo, establishing remote, and checking out master
DEBUG:git.cmd:Popen(['git', 'init'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
INFO:root:Adding remote
DEBUG:root:Working directory: /cds/home/z/zlentz/temp/.tc-release-tmp, Repo: git@github.com:pcdshub/lcls-plc-kfe-motion.git
DEBUG:git.cmd:Popen(['git', 'remote', 'add', 'origin', 'git@github.com:pcdshub/lcls-plc-kfe-motion.git'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'fetch', '-v', 'origin'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=True, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'cat-file', '--batch-check'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=<valid stream>)
DEBUG:git.cmd:Popen(['git', 'checkout', 'master'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
INFO:root:Looking for .plcproj
INFO:root:Parsing plcproj
INFO:root:Updating plcproj with version number: 1.3.2
INFO:root:Creating Global_Version.TcGVL
INFO:root:Writing Global_Version.TcGVL to file
INFO:root:File created successfully: /cds/home/z/zlentz/temp/.tc-release-tmp/plc-kfe-motion/kfe_motion/Version/Global_Version.TcGVL
INFO:root:Linking Global_Version.TcGVL into plcproj
INFO:root:Writing updated .plcproj to file
INFO:root:.plc project has been updated
INFO:root:Committing changes
DEBUG:git.cmd:Popen(['git', 'cat-file', '--batch'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=<valid stream>)
DEBUG:git.cmd:Popen(['git', 'tag', '-m', 'Tagging version v1.3.2', 'v1.3.2', 'HEAD'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=False, shell=None, istream=None)
DEBUG:git.cmd:Popen(['git', 'push', '--porcelain', '--tags', 'origin'], cwd=/cds/home/z/zlentz/temp/.tc-release-tmp, universal_newlines=True, shell=None, istream=None)
INFO:root:Push complete
Deploying lcls-plc-kfe-motion to /cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion at v1.3.2
Deploying to /cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2
DEBUG:git.cmd:Popen(['git', 'clone', '--branch=v1.3.2', '--depth=1', '-v', 'git@github.com:pcdshub/lcls-plc-kfe-motion.git', '/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2'], cwd=/cds/home/z/zlentz/temp, universal_newlines=True, shell=None, istream=None)
DEBUG:git.repo.base:Cmd(['git', 'clone', '--branch=v1.3.2', '--depth=1', '-v', 'git@github.com:pcdshub/lcls-plc-kfe-motion.git', '/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2'])'s unused stdout:
-----------------------------------------------------------
Build path: /cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/.pytmc_build
PLC: kfe_motion
IOC name: ioc-kfe-motion
PYTMC_OPTS:
PROJECT_PATH: ../../plc-kfe-motion/plc-kfe-motion.tsproj
Absolute project path:  /cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/plc-kfe-motion/plc-kfe-motion.tsproj
-----------------------------------------------------------


mkdir -p "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/.pytmc_build"
make[1]: Entering directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'
* Found pytmc v 2.8.0
Executing pytmc stcmd: creating st.cmd...
cd "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/.pytmc_build" && \
        pytmc stcmd \
        --name "ioc-kfe-motion" \
        --plc "kfe_motion" \
        --template-path "/reg/g/pcds/epics/ioc/common/ads-ioc/R0.3.1/iocBoot/templates" \
        --template "st.cmd.template" \
        --hashbang "/reg/g/pcds/epics/ioc/common/ads-ioc/R0.3.1/bin/rhel7-x86_64/adsIoc" \
        --only-motor \
        -p "PLC:KFE:MOTION" \
         \
        "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/plc-kfe-motion/plc-kfe-motion.tsproj" > st.cmd
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'
make[1]: Entering directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'
* Found pytmc v 2.8.0
Executing pytmc db: creating kfe_motion.db and kfe_motion.archive...
cd "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/.pytmc_build" && \
        pytmc db \
        --plc "kfe_motion" \
        "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/plc-kfe-motion/plc-kfe-motion.tsproj" \
        "kfe_motion.db"
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'
make[1]: Entering directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'
* Copying envPaths and fixing IOC_TOP...
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'
make[1]: Entering directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'

* Copying st.cmd and databases...
* Changing permissions on the old st.cmd...
* Found database files to install; creating load_plc_databases.cmd...
* Installing: kfe_motion.db
* Installing: st.cmd
install -p -m 0555 "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/.pytmc_build/st.cmd" "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion";
* Installing: load_plc_databases.cmd
install -p -m 0444 "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/.pytmc_build/load_plc_databases.cmd" "/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion";
* Installing archive file: kfe_motion.db.archive
make[1]: Leaving directory `/cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion'

Build complete.
Creating IOC data directory
install --mode 0775 --group ps-ioc --directory /reg/d/iocData/ioc-kfe-motion/{iocInfo,archive,logs,autosave}
Creating autosave files directory
install --mode 0775 --group ps-ioc --directory /cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/autosave

* Cleaning...
Done
INFO:root:Cleaning up

$ ls /cds/group/pcds/epics/ioc/kfe/lcls-plc-kfe-motion/v1.3.2/iocBoot/ioc-kfe-motion/
autosave  envPaths  kfe_motion.db  kfe_motion.db.archive  load_plc_databases.cmd  Makefile  st.cmd
```