### PR TITLE
MNT: fix include checks that I broke

### DIFF
--- a/tc_release/tc_release.py
+++ b/tc_release/tc_release.py
@@ -413,14 +413,17 @@ def make_release(args, repo):
     logger.info('Linking Global_Version.TcGVL into plcproj')
 
     # Check if Version folder is already linked, if not add it
-    ver_find = ".//ItemGroup/Folder[@Include='Version']"
-    if not len(plcproj_root.find(ver_find, nsmap)):
+    folder_find = ".//ItemGroup/Folder[@Include='Version']"
+    ver_folders = plcproj_root.find(folder_find, nsmap)
+    if ver_folders is None or not len(ver_folders):
         folder = plcproj_root.find('.//ItemGroup/Folder', nsmap)
         folder.addnext(etree.XML('<Folder Include="Version" />'))
 
     # Check if Compile Include if not add it (it better already be there)
-    comp_find = r'.//ItemGroup/Compile[@Include="Version\Global_Version.TcGVL"]'
-    if not len(plcproj_root.find(comp_find, nsmap)):
+    compile_find = (r'.//ItemGroup/Compile'
+                    r'[@Include="Version\Global_Version.TcGVL"]')
+    ver_compiles = plcproj_root.find(compile_find, nsmap)
+    if ver_compiles is None or not len(ver_compiles):
         compile_include = plcproj_root.find('.//ItemGroup/Compile', nsmap)
         compile_include.addnext(etree.XML(r'''
         <Compile Include="Version\Global_Version.TcGVL">


### PR DESCRIPTION
Something that I broke when I was trying to get rid of a noisy deprecation warning in the xml library we're using.

These finds can come up as None or as an empty list. The original code before #19 simply checks `not find` which covers both cases, but invokes a pretty noisy deprecation warning that says "don't do this, we're going to change the behavior at some point, compare against `None` or use `len` instead."

I'm not 100% sure under which cases I'm supposed to expect `None` type or empty list, but this covers all the bases and allowed the kfe-motion project to tag/deploy again.